### PR TITLE
dbus-modbus-client-1.57/Shelly Pro 3EM

### DIFF
--- a/dbus-modbus-client.py
+++ b/dbus-modbus-client.py
@@ -33,6 +33,7 @@ import dse
 import ev_charger
 import smappee
 import victron_em
+import shelly
 
 import logging
 log = logging.getLogger()

--- a/shelly.py
+++ b/shelly.py
@@ -59,7 +59,7 @@ class Shelly_Pro_3EM(Shelly_Meter):
 
 models = {
     Shelly_Pro_3EM.productid: {
-        'model':    'SPEM-003CE',
+        'model':    'SPEM-003CEBEU',
         'handler':  Shelly_Pro_3EM,
     },
 }

--- a/shelly.py
+++ b/shelly.py
@@ -4,22 +4,14 @@ import device
 import probe
 from register import *
 
-log = logging.getLogger(__name__)
-
-
-class ShellyEnergyMeter(device.CustomName, device.EnergyMeter):
-    # Define mandatory properties so the device gets saved
-    productid = 0xFFFF
-    productname = 'Shelly Energy Meter'
+class Shelly_Meter(device.CustomName, device.EnergyMeter):
+    vendor_id = 'shelly'
+    vendor_name = 'Shelly'
 
     min_timeout = 0.5
-    # Shelly Modbus devices oddly use input registers for everything
     default_access = 'input'
-    nr_phases = 3
 
     def device_init(self):
-        log.info('Initializing Shelly energy meter using connection "%s"', self.connection())
-
         self.info_regs = [
             Reg_text(0, 6, '/Serial', little=True),
             Reg_text(6, 10, '/ProductName', little=True),
@@ -29,33 +21,49 @@ class ShellyEnergyMeter(device.CustomName, device.EnergyMeter):
             Reg_f32l(1162, '/Ac/Energy/Forward', 1000, '%.1f kWh'),
             Reg_f32l(1164, '/Ac/Energy/Reverse', 1000, '%.1f kWh'),
             Reg_f32l(1013, '/Ac/Power', 1, '%.1f W'),
-            Reg_f32l(1182, '/Ac/L1/Energy/Forward', 1000, '%.1f kWh'),
-            Reg_f32l(1184, '/Ac/L1/Energy/Reverse', 1000, '%.1f kWh'),
+
             Reg_f32l(1020, '/Ac/L1/Voltage', 1, '%.1f V'),
             Reg_f32l(1022, '/Ac/L1/Current', 1, '%.1f A'),
-            Reg_f32l(1024, '/Ac/L1/Power', 1, '%.1f W'),
-            Reg_f32l(1202, '/Ac/L2/Energy/Forward', 1000, '%.1f kWh'),
-            Reg_f32l(1204, '/Ac/L2/Energy/Reverse', 1000, '%.1f kWh'),
-            Reg_f32l(1040, '/Ac/L2/Voltage', 1, '%.1f V'),
-            Reg_f32l(1042, '/Ac/L2/Current', 1, '%.1f A'),
-            Reg_f32l(1044, '/Ac/L2/Power', 1, '%.1f W'),
-            Reg_f32l(1222, '/Ac/L3/Energy/Forward', 1000, '%.1f kWh'),
-            Reg_f32l(1224, '/Ac/L3/Energy/Reverse', 1000, '%.1f kWh'),
-            Reg_f32l(1060, '/Ac/L3/Voltage', 1, '%.1f V'),
-            Reg_f32l(1062, '/Ac/L3/Current', 1, '%.1f A'),
-            Reg_f32l(1064, '/Ac/L3/Power', 1, '%.1f W'),
+
         ]
         
     def get_ident(self):
         return 'shelly_{}'.format(self.info['/Serial'])
 
 
-class ShellyModelRegister(probe.ModelRegister):
-    def __init__(self, **args):
-        super().__init__(None, [], **args)
+class Shelly_Pro_3EM(Shelly_Meter):
+    productname = 'Shelly Pro 3EM'
+    productid = 0xFFFF
+    nr_phases = 3
 
-    def probe(self, spec, modbus, timeout=None):
-        return ShellyEnergyMeter(spec, modbus, 'SPEM-003CE')
+    def device_init(self):
+        super().device_init()
 
+        self.data_regs += [
+            Reg_f32l(1182, '/Ac/L1/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1184, '/Ac/L1/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1024, '/Ac/L1/Power', 1, '%.1f W'),
 
-probe.add_handler(ShellyModelRegister(methods=['tcp'], units=[1]))
+            Reg_f32l(1040, '/Ac/L2/Voltage', 1, '%.1f V'),
+            Reg_f32l(1042, '/Ac/L2/Current', 1, '%.1f A'),
+            Reg_f32l(1202, '/Ac/L2/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1204, '/Ac/L2/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1044, '/Ac/L2/Power', 1, '%.1f W'),
+
+            Reg_f32l(1060, '/Ac/L3/Voltage', 1, '%.1f V'),
+            Reg_f32l(1062, '/Ac/L3/Current', 1, '%.1f A'),
+            Reg_f32l(1222, '/Ac/L3/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1224, '/Ac/L3/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1064, '/Ac/L3/Power', 1, '%.1f W'),
+        ]
+
+models = {
+    Shelly_Pro_3EM.productid: {
+        'model':    'SPEM-003CE',
+        'handler':  Shelly_Pro_3EM,
+    },
+}
+
+probe.add_handler(probe.ModelRegister(Reg_u16(0x2000), models,
+                                      methods=['tcp'],
+                                      units=[1]))

--- a/shelly.py
+++ b/shelly.py
@@ -1,0 +1,61 @@
+import logging
+
+import device
+import probe
+from register import *
+
+log = logging.getLogger(__name__)
+
+
+class ShellyEnergyMeter(device.CustomName, device.EnergyMeter):
+    # Define mandatory properties so the device gets saved
+    productid = 0xFFFF
+    productname = 'Shelly Energy Meter'
+
+    min_timeout = 0.5
+    # Shelly Modbus devices oddly use input registers for everything
+    default_access = 'input'
+    nr_phases = 3
+
+    def device_init(self):
+        log.info('Initializing Shelly energy meter using connection "%s"', self.connection())
+
+        self.info_regs = [
+            Reg_text(0, 6, '/Serial', little=True),
+            Reg_text(6, 10, '/ProductName', little=True),
+        ]
+
+        self.data_regs = [
+            Reg_f32l(1162, '/Ac/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1164, '/Ac/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1013, '/Ac/Power', 1, '%.1f W'),
+            Reg_f32l(1182, '/Ac/L1/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1184, '/Ac/L1/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1020, '/Ac/L1/Voltage', 1, '%.1f V'),
+            Reg_f32l(1022, '/Ac/L1/Current', 1, '%.1f A'),
+            Reg_f32l(1024, '/Ac/L1/Power', 1, '%.1f W'),
+            Reg_f32l(1202, '/Ac/L2/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1204, '/Ac/L2/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1040, '/Ac/L2/Voltage', 1, '%.1f V'),
+            Reg_f32l(1042, '/Ac/L2/Current', 1, '%.1f A'),
+            Reg_f32l(1044, '/Ac/L2/Power', 1, '%.1f W'),
+            Reg_f32l(1222, '/Ac/L3/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1224, '/Ac/L3/Energy/Reverse', 1000, '%.1f kWh'),
+            Reg_f32l(1060, '/Ac/L3/Voltage', 1, '%.1f V'),
+            Reg_f32l(1062, '/Ac/L3/Current', 1, '%.1f A'),
+            Reg_f32l(1064, '/Ac/L3/Power', 1, '%.1f W'),
+        ]
+        
+    def get_ident(self):
+        return 'shelly_{}'.format(self.info['/Serial'])
+
+
+class ShellyModelRegister(probe.ModelRegister):
+    def __init__(self, **args):
+        super().__init__(None, [], **args)
+
+    def probe(self, spec, modbus, timeout=None):
+        return ShellyEnergyMeter(spec, modbus, 'SPEM-003CE')
+
+
+probe.add_handler(ShellyModelRegister(methods=['tcp'], units=[1]))


### PR DESCRIPTION
Hey @jalle19, I'm creating this PR to ask something. You can disregard the code.

I'm trying to make the Shelly Pro 3EM work on Venus OS 3.50+ and have used your fork as the starting point. As far as I can tell they've implemented the missing features (formal support for input registers) and have refined the API even further to the point that adding support for any EM is just a matter of importing it.

With that said Modbus TCP/UDP devices -> Saved devices appears to have no effect whatsoever. Whether I use a correct IP or something totally random. It saves it but appears to do absolutely nothing with it. I'm out of ideas and am wondering if there is some hidden place where dbus-modbus-client logs connection errors and such. Your feedback is appreciated. Thx!